### PR TITLE
Optimize for mobile hide menu and hide some toolbar content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jack-homepage",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^0.483.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.3.0"
@@ -2198,6 +2199,15 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.483.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.483.0.tgz",
+      "integrity": "sha512-WldsY17Qb/T3VZdMnVQ9C3DDIP7h1ViDTHVdVGnLZcvHNg30zH/MTQ04RTORjexoGmpsXroiQXZ4QyR0kBy0FA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "lucide-react": "^0.483.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.3.0"

--- a/src/components/MenuOverlay.jsx
+++ b/src/components/MenuOverlay.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { X } from 'lucide-react';
 
-const MenuOverlay = () => {
+const MenuOverlay = ({ onClose }) => {
     const menuItems = [
         { label: "PROJECTS", path: "/projects" },
         { label: "RESUME", path: "/resume" },
@@ -45,8 +46,8 @@ const MenuOverlay = () => {
                     }
                     break;
                 case 'Escape':
-                    // Clear selection
-                    setSelectedIndex(null);
+                    // Close menu
+                    onClose();
                     break;
                 default:
                     break;
@@ -56,7 +57,7 @@ const MenuOverlay = () => {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, [menuItems.length, navigate, selectedIndex]);
+    }, [menuItems.length, navigate, selectedIndex, onClose]);
 
     // Set hovered index when selected changes
     useEffect(() => {
@@ -96,7 +97,8 @@ const MenuOverlay = () => {
                 padding: '10px',
                 textAlign: 'center',
                 borderBottom: '1px solid #555',
-                boxShadow: '0 2px 5px rgba(0, 0, 0, 0.3)'
+                boxShadow: '0 2px 5px rgba(0, 0, 0, 0.3)',
+                position: 'relative'
             }}>
                 <h2 style={{
                     margin: 0,
@@ -105,6 +107,31 @@ const MenuOverlay = () => {
                     letterSpacing: '2px',
                     textShadow: '0 2px 2px rgba(0, 0, 0, 0.5)'
                 }}>MAIN MENU</h2>
+
+                {/* Close button - always shown */}
+                <div
+                    onClick={() => {
+                        console.log("Close button clicked in MenuOverlay");
+                        if (onClose) onClose();
+                    }}
+                    style={{
+                        position: 'absolute',
+                        right: '10px',
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        cursor: 'pointer',
+                        color: 'white',
+                        backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                        borderRadius: '3px',
+                        padding: '4px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        zIndex: 1010
+                    }}
+                >
+                    <X size={16} />
+                </div>
             </div>
 
             {/* Menu items */}

--- a/src/components/TerminalIcon.jsx
+++ b/src/components/TerminalIcon.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Terminal } from 'lucide-react';
+
+// Icon that triggers the menu to be shown
+const TerminalIcon = ({ onClick }) => {
+    return (
+        <div
+            onClick={onClick}
+            style={{
+                position: 'fixed',
+                top: '16px',
+                right: '16px',
+                zIndex: 1000,
+                cursor: 'pointer',
+                padding: '8px',
+                borderRadius: '50%',
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+                boxShadow: '0 0 10px 2px rgba(0, 255, 255, 0.7)',
+                animation: 'pulse 2s infinite alternate'
+            }}
+        >
+            <Terminal
+                size={24}
+                color="#0ff" // Cyan color
+            />
+            <style jsx="true">{`
+        @keyframes pulse {
+          0% {
+            box-shadow: 0 0 10px 2px rgba(0, 255, 255, 0.7);
+          }
+          100% {
+            box-shadow: 0 0 15px 4px rgba(0, 255, 255, 0.9);
+          }
+        }
+      `}</style>
+        </div>
+    );
+};
+
+export default TerminalIcon;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -51,16 +51,13 @@ const HomePage = () => {
             // Only reset if change is significant (>15%)
             if (widthChange > 0.15 || heightChange > 0.15) {
                 console.log('Significant resize detected, resetting FloatingCharacters');
-
-                // Update stored dimensions
                 setScreenDimensions({ width: newWidth, height: newHeight });
-
-                // Force component reset by changing key
+                // Force recreate FloatingCharacters
                 setFloatingCharKey(prevKey => prevKey + 1);
             }
         };
 
-        // Create debounced resize handler (waits 300ms after resize stops)
+        // 300ms debounce
         const debouncedResizeHandler = debounce(handleResizeComplete, 300);
         window.addEventListener('resize', debouncedResizeHandler);
         // Cleanup on component unmount
@@ -85,7 +82,7 @@ const HomePage = () => {
             {/* Floating Characters background - shown on all devices */}
             <FloatingCharacters key={floatingCharKey} />
 
-            {/* Hamburger menu button - only visible when menu is hidden */}
+            {/* Terminal menu button - only visible when menu is hidden */}
             {!isMenuVisible && <TerminalIcon onClick={toggleMenu} />}
 
             {/* Menu Overlay - shown when isMenuVisible is true */}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,6 +3,10 @@ import FloatingCharacters from '../components/FloatingCharacters';
 import MenuOverlay from '../components/MenuOverlay';
 import TerminalIcon from '../components/TerminalIcon';
 
+// Reference to menu width (default menu width is 340px based on MenuOverlay.jsx)
+const MENU_WIDTH = 340;
+const MINIMUM_PADDING = 60; // Space for playing with characters
+
 // Simple debounce function
 const debounce = (func, delay) => {
     let timeoutId;
@@ -24,10 +28,6 @@ const HomePage = () => {
 
     // Need enough space to allow playing with characters
     const [isMenuVisible, setIsMenuVisible] = useState(true);
-
-    // Reference to menu width (default menu width is 340px based on MenuOverlay.jsx)
-    const MENU_WIDTH = 340;
-    const MINIMUM_PADDING = 20; // Space for playing with characters
 
     // Check if screen is narrow on initial load and set menu visibility accordingly
     useEffect(() => {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -15,6 +15,7 @@ const HomePage = () => {
     // Unique ID for FloatingCharacters component so that we can destroy and recreate on resize
     const [floatingCharKey, setFloatingCharKey] = useState(0);
 
+    // Track current screen dimensions
     const [screenDimensions, setScreenDimensions] = useState({
         width: window.innerWidth,
         height: window.innerHeight


### PR DESCRIPTION
- Allow hiding of Menu
- Create TerminalIcon to unhide the Menu
- Hide menu by default if screen width is small
- Hide toolbar elements on mobile (keyboard controls, clock, "back" in back button)